### PR TITLE
Fixed a bug with recentering at end of file

### DIFF
--- a/centered-cursor-mode.el
+++ b/centered-cursor-mode.el
@@ -339,7 +339,9 @@ the center. Just the variable ccm-vpos is set."
                                            (goto-char (point-max))
                                            (zerop (current-column))))
                                      1 0)))
-                   (window-is-at-bottom (= (window-end) (point-max)))
+                   (window-is-at-bottom (or (= (window-end) (point-max)) ; doesn't work when scrolling (eg. pgdwn)
+                                            (= (line-end-position ccm-vpos) (point-max)) ; doesn't work on repls second to last line, because the prompt gets inserted later?
+                                            ))
                    ;; lines from point to end of buffer
                    (bottom-lines (if window-is-at-bottom
                                      (+ (count-lines (point) (point-max))


### PR DESCRIPTION
CCM doesn't recenter correctly when you have this option:

(setq ccm-recenter-at-end-of-file nil)

and do (end-of-buffer) or (ccm-scroll-up). It first recenters in
the middle of the window. Only then, after another command, it
recenters correctly at the bottom.

Line 341 doesn't work as intended because (window-end) doesn't
return the right value when the window scrolls. At that point in
time, when line 341 gets run, the value of (point) is bigger
then (window-end).

I don't know what kind of work line-end-position has to do behind
the scenes, but I haven't noticed any ill effects. But I also
haven't tested it with really big files.