### PR TITLE
Fix aggressive centering while dragging mouse

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 - interactive first start isn't animated when calling `global-...` because it starts the modes for each buffer and `interactive-p` fails for that
 - don't load keyboard shortcuts (like `C-M-+`) by default and provide function to load (like `(ffap-bindings)`)
-- selecting text with mouse scrolls (`last-command` variable contains an event in this case)
 - use `(while-no-input ...)`? see `post-command-hook` doc
 - recalculate cursor position on some events like after `(default-text-scale)` if necessary
 - acceleration on S-scroll like in `mwheel-scroll`

--- a/centered-cursor-mode.el
+++ b/centered-cursor-mode.el
@@ -235,6 +235,8 @@ This command exists, because mwheel-scroll caused strange
 behaviour with automatic recentering."
 ;;  (interactive (list last-input-event))
   (interactive "e")
+  (when (region-active-p)
+    (deactivate-mark))
   (let* ((mods (delq 'click (delq 'double (delq 'triple (event-modifiers event)))))
          (amt (assoc mods mouse-wheel-scroll-amount)))
     ;;(message "%S" mods)
@@ -320,7 +322,7 @@ the center. Just the variable ccm-vpos is set."
 
 (defun ccm-position-cursor ()
   "Do the actual recentering at the position `ccm-vpos'."
-  (unless (member this-command ccm-ignored-commands)
+  (unless (or (member this-command ccm-ignored-commands) (mouse-movement-p last-command-event))
     (unless ccm-vpos
       (ccm-vpos-recenter))
     (unless (minibufferp (current-buffer))


### PR DESCRIPTION
I've been using this patch for a few months, and this seems to fix all issues (that I know of) related to mouse-dragging with `centered-cursor-mode` active.

I don't write a ton of elisp outside of my own config, so let me know if you have any feedback or if there is a better way to solve this.